### PR TITLE
fix: specify bash as the shell to use

### DIFF
--- a/add.sh
+++ b/add.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # utils or hoisted functions
 
 function err {


### PR DESCRIPTION
### Problem
I tried to invoke the add.sh script as a git alias, i.e. `git config --local alias.addsh '!./add.sh'`, but in vain.
```bash
$ git addsh 2.1
./add.sh: 3: function: not found
error: 2.1
./add.sh: 5: Syntax error: "}" unexpected
```
### Solution
So I made [a quick search](https://stackoverflow.com/questions/12468889/bash-script-error-function-not-found-why-would-this-appear) and got to know that this problem was due to the absence of a shebang. In this reason, I made it explicit the shell to interpret this script.