### PR TITLE
fix: abort add.sh when EDITOR fails

### DIFF
--- a/add.sh
+++ b/add.sh
@@ -80,7 +80,7 @@ if [ ! -f "$readme" ]; then
   echo "No README found for $chapter. Opening an editor to create a new one."
   echo "(Set the EDITOR environment variable to change the editor.)"
   echo "# $chapter " > "$readme"
-  $editor "$readme"
+  $editor "$readme" || exit 1
   git add "$readme"
   echo "done"
 
@@ -113,7 +113,7 @@ fi
 echo "Hello, $author. You are currently located at '$path'"
 
 echo "Opening editor for summary creation..."
-$editor $filename
+$editor $filename || exit 1
 echo "done"
 
 echo "Staging the summary..."


### PR DESCRIPTION
# Summary
- Ensure add.sh stops execution immediately if the EDITOR command fails, preventing unintended subsequent actions.

# Problem
- When running add.sh, the script continues executing even if the EDITOR process fails (non-zero exit), which can lead to unintended behavior.

# Solution
- Modify the script to detect EDITOR failure and exit immediately with a non-zero status.
- This prevents any further steps from running when the editor cannot be launched or returns an error.
